### PR TITLE
Fix pool addition race and baseline raw parse panic

### DIFF
--- a/core/baseline/baseline.go
+++ b/core/baseline/baseline.go
@@ -51,17 +51,10 @@ func NewBaseline(u, host string, resp *ihttp.Response) *Baseline {
 	}
 
 	bl.Raw = append(bl.Header, bl.Body...)
-	bl.Response, err = pkg.ParseRawResponse(bl.Raw)
-	if err != nil {
-		bl.IsValid = false
-		bl.Reason = pkg.ErrResponseError.Error()
-		bl.ErrString = err.Error()
-		return bl
-	}
-	if r := bl.Response.Header.Get("Location"); r != "" {
+	if r := resp.GetHeader("Location"); r != "" {
 		bl.RedirectURL = r
 	} else {
-		bl.RedirectURL = bl.Response.Header.Get("location")
+		bl.RedirectURL = resp.GetHeader("location")
 	}
 
 	bl.Dir = bl.IsDir()

--- a/core/pool/brutepool.go
+++ b/core/pool/brutepool.go
@@ -678,8 +678,9 @@ func (pool *BrutePool) Close() {
 		// 等待缓存的待处理任务完成
 		time.Sleep(time.Duration(100) * time.Millisecond)
 	}
-	close(pool.additionCh) // 关闭addition管道
-	//close(pool.checkCh)    // 关闭check管道
+	pool.additionClosed.Store(true)
+	// additionCh may still have async producers (redirect/crawl/retry/append);
+	// rely on closeCh/ctx to stop the consumer loop instead of closing the channel.
 	pool.Statistor.EndTime = time.Now().Unix()
 	pool.reqPool.Release()
 	pool.scopePool.Release()

--- a/core/pool/pool.go
+++ b/core/pool/pool.go
@@ -21,12 +21,13 @@ type BasePool struct {
 	ctx       context.Context
 	processCh chan *baseline.Baseline // 待处理的baseline
 
-	reqCount    int
-	failedCount int
-	additionCh  chan *Unit
-	closeCh     chan struct{}
-	wg          *sync.WaitGroup
-	isFallback  atomic.Bool
+	reqCount       int
+	failedCount    int
+	additionCh     chan *Unit
+	closeCh        chan struct{}
+	wg             *sync.WaitGroup
+	isFallback     atomic.Bool
+	additionClosed atomic.Bool
 }
 
 func (pool *BasePool) doRetry(bl *baseline.Baseline) {
@@ -44,12 +45,31 @@ func (pool *BasePool) doRetry(bl *baseline.Baseline) {
 }
 
 func (pool *BasePool) addAddition(u *Unit) {
+	if pool.ctx.Err() != nil || pool.additionClosed.Load() {
+		return
+	}
+
 	pool.wg.Add(1)
+	defer func() {
+		if recover() != nil {
+			pool.wg.Done()
+		}
+	}()
+
 	select {
+	case <-pool.ctx.Done():
+		pool.wg.Done()
+		return
 	case pool.additionCh <- u:
+		return
 	default:
 		// 强行屏蔽报错, 防止goroutine泄露
 		go func() {
+			defer func() {
+				if recover() != nil {
+					pool.wg.Done()
+				}
+			}()
 			select {
 			case pool.additionCh <- u:
 			case <-pool.ctx.Done():


### PR DESCRIPTION
## Summary

  - fix a race where async producers may still send to `additionCh` after shutdown
  - avoid closing `additionCh` in `BrutePool.Close()` and rely on existing shutdown signals
  - remove redundant raw HTTP response reparsing in `baseline.NewBaseline()` and read `Location` directly from the live response

  ## Why

  This fixes two crash classes observed in production:

  - `panic: send on closed channel`
  - failures around raw response reparsing such as stacks involving `bufio.(*Reader).Peek`

  ## Validation

  - `go build ./...` passes locally